### PR TITLE
Update to the latest dynapath

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :aot :all
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [clj-tair "1.0.0-SNAPSHOT"]
-                 [dynapath "0.2.0"]
+                 [org.tcrawley/dynapath "0.2.3"]
                  [fs "1.3.2"]
                  [colorize "0.1.1"]
                  [jline "2.9"]])


### PR DESCRIPTION
This commit addresses two issues:
- dynapath is now org.tcrawley/dynapath - it needed a proper group-id
  to go to maven central, which was a requirement for pomegranate.
- 0.2.3 addresses an issue that allowed modification the boot
  classloader, which wreaked havoc.

I'm not sure if you are using the classloader modification
functionality, but if you are, I don't want you to get bitten by the
boot classloader modification - it is very painful to debug.
